### PR TITLE
add AWSCloudFormationFullAccess to GithubCDKRole

### DIFF
--- a/role-template.yml
+++ b/role-template.yml
@@ -18,6 +18,8 @@ Resources:
               StringLike:
                 'token.actions.githubusercontent.com:sub': !Sub 'repo:${GitHubAccount}/*'
                 'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AWSCloudFormationFullAccess'
       Policies:
         - PolicyName: GitHubCDKActionsPolicy
           PolicyDocument:


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Adds full access to CloudFormation to the role.

## What is the current behavior? (You can also link to an open issue here)
Deployments in js-assertion-cheat-sheet fail because this policy is missing.

## What is the new behavior (if this is a feature change)?
Deployment with AWS CDK will successfully complete now.

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## Other information:
